### PR TITLE
Build was failing on jscpd...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 cache: pip
 install:
   - pip3 install -r requirements.txt
+  - nvm install 10 
   - npm install -g jscpd
 jobs:
   include:


### PR DESCRIPTION
# Root cause
Travis broke the build by changing the build environment.
Version of `node` changed and `jscpd` was dependent on that.

# Solution
Now we install `node` version `10` with `nvm` and `jscpd` works as expected.

# Evidence
https://travis-ci.com/github/JeroenKnoops/TextSimilarityProcessor/builds/160620895